### PR TITLE
Fix for privilege dropping

### DIFF
--- a/chargen.c
+++ b/chargen.c
@@ -34,6 +34,7 @@
 #define SIZELEN		16
 #define SAFEUSR		"nobody"
 #define SAFEGRP		"nobody"
+#define SAFEGRP2	"nogroup"
 
 #define XSTR(s)		STR(s)
 #define STR(s)		#s
@@ -193,7 +194,9 @@ void drop_privileges(void)
 		return;
 
 	if ((grp = getgrnam(SAFEGRP)) == NULL)
-		ERROR("getgrnam");
+		if ((grp = getgrnam(SAFEGRP2)) == NULL)
+			ERROR("getgrnam");
+		
 	if (setgid(grp->gr_gid) == -1)
 		ERROR("setgid");
 


### PR DESCRIPTION
Debian -based systems like Ubuntu uses the name nogroup instead of nobody for the name of the default unprivileged group. 

This fix first tries to set the group to nobody and if that fail tries with nogroup before bailing
out with an error.